### PR TITLE
Implement password reset flow

### DIFF
--- a/lib/screens/auth/forgot_password_screen.dart
+++ b/lib/screens/auth/forgot_password_screen.dart
@@ -1,0 +1,132 @@
+// lib/screens/auth/forgot_password_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:geziyorum/main.dart';
+
+class ForgotPasswordScreen extends StatefulWidget {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  State<ForgotPasswordScreen> createState() => _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  bool _isSending = false;
+
+  Future<void> _sendResetEmail() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _isSending = true;
+    });
+    try {
+      await FirebaseAuth.instance
+          .sendPasswordResetEmail(email: _emailController.text.trim());
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Şifre sıfırlama e-postası gönderildi.')),
+        );
+        Navigator.pop(context);
+      }
+    } on FirebaseAuthException catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message ?? 'Bir hata oluştu.')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Bir hata oluştu: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSending = false;
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.backgroundColor,
+      appBar: AppBar(
+        title: const Text(
+          'Şifre Sıfırla',
+          style: TextStyle(color: AppColors.white, fontWeight: FontWeight.bold),
+        ),
+        backgroundColor: AppColors.primaryColor,
+      ),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24.0),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.lock_reset, size: 80, color: AppColors.primaryColor),
+                const SizedBox(height: 30),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: InputDecoration(
+                    labelText: 'E-posta',
+                    hintText: 'e-postanızı girin',
+                    prefixIcon:
+                        const Icon(Icons.email, color: AppColors.primaryColor),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10.0),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10.0),
+                      borderSide:
+                          const BorderSide(color: AppColors.primaryColor, width: 2),
+                    ),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Lütfen e-posta adresinizi girin.';
+                    }
+                    if (!value.contains('@') || !value.contains('.')) {
+                      return 'Geçerli bir e-posta adresi girin.';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 20),
+                _isSending
+                    ? const CircularProgressIndicator()
+                    : ElevatedButton(
+                        onPressed: _sendResetEmail,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.primaryColor,
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 50, vertical: 15),
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10)),
+                          minimumSize: const Size(double.infinity, 50),
+                        ),
+                        child: const Text(
+                          'Gönder',
+                          style: TextStyle(
+                              fontSize: 18,
+                              color: AppColors.white,
+                              fontWeight: FontWeight.bold),
+                        ),
+                      ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:geziyorum/services/auth_service.dart'; // AuthService'i import et
 import 'package:geziyorum/main.dart'; // AppColors için (veya colors.dart gibi ayrı bir dosyanız varsa oradan)
 import 'package:geziyorum/screens/auth/register_screen.dart'; // RegisterScreen'e geçiş için
+import 'package:geziyorum/screens/auth/forgot_password_screen.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart'; // Font Awesome için bu satırı etkinleştirin
 
 class LoginScreen extends StatefulWidget {
@@ -173,15 +174,19 @@ class _LoginScreenState extends State<LoginScreen> {
                   alignment: Alignment.centerRight,
                   child: TextButton(
                     onPressed: () {
-                      // Şifre sıfırlama ekranına yönlendirme
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Şifre sıfırlama özelliği yakında!')),
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const ForgotPasswordScreen(),
+                        ),
                       );
-                      // Navigator.push(context, MaterialPageRoute(builder: (context) => ForgotPasswordScreen()));
                     },
                     child: const Text(
                       'Şifremi unuttum?',
-                      style: TextStyle(color: AppColors.primaryColor, fontWeight: FontWeight.bold),
+                      style: TextStyle(
+                        color: AppColors.primaryColor,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- add a forgot password screen to send reset emails
- link Login screen to the new screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684845bd30dc8323b3e151594084f945